### PR TITLE
Bug fix: Avoid the reuse of IDs in the diagrams, which resulted in ha…

### DIFF
--- a/src/org/gk/persistence/GKBReader.java
+++ b/src/org/gk/persistence/GKBReader.java
@@ -632,6 +632,7 @@ public class GKBReader implements RenderablePropertyNames {
             r = createRenderableFromType(elmName);
         }
         r.setID(Integer.parseInt(id));
+        RenderableRegistry.getRegistry().suggestNextId(Integer.parseInt(id));
         String reactomeId = elm.getAttributeValue("reactomeId");
         if (reactomeId != null && reactomeId.length() > 0)
             r.setReactomeId(Long.parseLong(reactomeId));

--- a/src/org/gk/render/RenderableRegistry.java
+++ b/src/org/gk/render/RenderableRegistry.java
@@ -46,8 +46,14 @@ public class RenderableRegistry {
     public void resetNextId(int id) {
         nextId = id;
     }
-    
-    public void open(RenderablePathway container) {
+
+	public void suggestNextId(int id) {
+		if(id>nextId) {
+			nextId = id;
+		}
+	}
+
+	public void open(RenderablePathway container) {
         clear();
         registerAll(container);
         resetNextIdFromPathway(container);


### PR DESCRIPTION
We propose this small change because we noticed a bug during XML generation for disease pathways. In some cases there are entities with the same diagramID inside the same XML file. The change we propose avoids the reuse of IDs in the diagrams, which results in having duplicates in some disease pathways.