### PR TITLE
Fix constants

### DIFF
--- a/src/org/gk/model/ReactomeJavaConstants.java
+++ b/src/org/gk/model/ReactomeJavaConstants.java
@@ -313,7 +313,7 @@ public class ReactomeJavaConstants {
     public static final String ProteinDrug = "ProteinDrug";
     public static final String RNADrug = "RNADrug";
     public static final String ReferenceTherapeutic = "ReferenceTherapeutic";
-    //public static final String abbreviation = "abbreviation"; // Already defined on line 308!
+    //Drugs need "abbreviation" though it is already defiend under "Species stable id prefix", line 308 (2017-10-19)
     public static final String inn = "inn";
     public static final String type = "type";
     public static final String approved = "approved";

--- a/src/org/gk/model/ReactomeJavaConstants.java
+++ b/src/org/gk/model/ReactomeJavaConstants.java
@@ -313,7 +313,7 @@ public class ReactomeJavaConstants {
     public static final String ProteinDrug = "ProteinDrug";
     public static final String RNADrug = "RNADrug";
     public static final String ReferenceTherapeutic = "ReferenceTherapeutic";
-    public static final String abbreviation = "abbreviation";
+    //public static final String abbreviation = "abbreviation"; // Already defined on line 308!
     public static final String inn = "inn";
     public static final String type = "type";
     public static final String approved = "approved";


### PR DESCRIPTION
The constant "abbreviation" was defined twice which caused compiler errors. 