### PR TITLE
Checks if 'identifier' is a valid attribute in StableIdentifier 

### DIFF
--- a/src/org/gk/qualityCheck/StableIdentifierCheck.java
+++ b/src/org/gk/qualityCheck/StableIdentifierCheck.java
@@ -452,9 +452,11 @@ public class StableIdentifierCheck extends AbstractQualityCheck {
                 instToValidStid.put(inst, newIdentifier);
                 continue; 
             }
-            String oldIdentifier = (String) stableId.getAttributeValue(ReactomeJavaConstants.identifier);
-            if (newIdentifier.equals(oldIdentifier))
-                continue;
+            if (stableId.getSchemClass().isValidAttribute(ReactomeJavaConstants.identifier)) {
+                String oldIdentifier = (String) stableId.getAttributeValue(ReactomeJavaConstants.identifier);
+                if (newIdentifier.equals(oldIdentifier))
+                    continue;
+            }
             instToValidStid.put(inst, newIdentifier);
             if (progressPane != null && progressPane.isCancelled())
                 break;


### PR DESCRIPTION
This was throwing 'InvalidAttributeExceptions' in the weekly qa due to a change in the Data Model, I believe. 