### PR TITLE
Fix qa checks using physical entity.compartment

### DIFF
--- a/src/org/gk/qualityCheck/ReactionCompartmentCheck.java
+++ b/src/org/gk/qualityCheck/ReactionCompartmentCheck.java
@@ -246,9 +246,7 @@ public class ReactionCompartmentCheck extends CompartmentCheck {
         {
             if (subclass.isValidAttribute(ReactomeJavaConstants.compartment))
             {
-                loadAttributes(ReactomeJavaConstants.PhysicalEntity,
-                       ReactomeJavaConstants.compartment,
-                       dba);
+                loadAttributes(subclass.getName(), ReactomeJavaConstants.compartment, dba);
             }
         }
     }


### PR DESCRIPTION
The PhysicalEntity class no longer has an attribute named "compartment", but some subclasses still have this attribute. Code that references PhysicalEntity.compartment needs to be updated.